### PR TITLE
Handle low balance gracefully on splash screen

### DIFF
--- a/script.mjs
+++ b/script.mjs
@@ -445,13 +445,15 @@ Press Enter to start.
         screen.render();
         const balance = await checkBalance();
         if (balance < MINIMUM_BUY_AMOUNT) {
-            updateLog('Insufficient balance to cover transaction and fees.');
-            process.exit(1);
+            updateLog('Insufficient balance to cover transaction and fees. Press Enter to exit.');
+            screen.removeAllListeners('enter');
+            screen.once('enter', () => process.exit(1));
         } else {
             const rentExemptionAmount = await calculateRentExemption(165);
             if (rentExemptionAmount && balance < MINIMUM_BUY_AMOUNT + rentExemptionAmount / 1e9) {
-                updateLog('Insufficient balance to cover rent exemption and transaction.');
-                process.exit(1);
+                updateLog('Insufficient balance to cover rent exemption and transaction. Press Enter to exit.');
+                screen.removeAllListeners('enter');
+                screen.once('enter', () => process.exit(1));
             } else {
                 main();
                 liveUpdateAccountInfo(); // Start live update of account info


### PR DESCRIPTION
## Summary
- Inform user about insufficient SOL balance or rent exemption shortfall and wait for confirmation before exiting.
- Remove prior `enter` key listeners when showing low-balance messages to avoid conflicting handlers.

## Testing
- `node --check script.mjs`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aca5b110f88325a948b9ea9baea9d9